### PR TITLE
feat: add shared legend panel and coverage

### DIFF
--- a/specs/master/visual-encoding.md
+++ b/specs/master/visual-encoding.md
@@ -167,6 +167,8 @@ Renderers must apply states in the following z-order (bottom → top):
 ## 7. Legend Synchronization Requirements
 
 - The shared `LegendPanel` component renders one entry for every `HighlightRole` declared in `HIGHLIGHT_COLOR_TOKENS`. Core roles are grouped into **Local states** (`current`, `frontier`, `queued`, `visited`) and **Global overlays** (`start`, `goal`, `path-active`, `path-final`, `obstacle`).
+- Each legend item **must** provide both a label and a descriptive sentence. Entries missing descriptions are automatically suppressed to prevent empty swatches.
+- The runtime legend filters itself to the highlight roles that actually appear in the active trace so learners only see states used by the current algorithm.
 - Plugins that introduce additional highlight roles must extend `HIGHLIGHT_COLOR_TOKENS` **and** pass `legend` groups to the panel so all colors remain documented in the UI.
 - When reusing existing roles in specialized ways (e.g., distinguishing multiple frontier queues), document the interpretation in the plugin README but keep the canonical label so learners see consistent terminology across visualizations.
 - Any pull request that modifies highlight colors or roles MUST include corresponding updates to the legend test coverage (`tests/unit/panels/LegendPanel.test.ts`).

--- a/specs/master/visual-encoding.md
+++ b/specs/master/visual-encoding.md
@@ -164,6 +164,13 @@ Renderers must apply states in the following z-order (bottom → top):
 - Automated renderers should expose a helper (e.g., `resolveStateStyles(state, theme)`) that reads directly from this spec to avoid divergence.
 - Algorithm categories not explicitly listed (e.g., tries, suffix arrays, monotonic stacks) must map their states to the closest descriptors here (`component`, `frontier`, `window`, `pruned`) or document new tokens with accessibility data.
 
+## 7. Legend Synchronization Requirements
+
+- The shared `LegendPanel` component renders one entry for every `HighlightRole` declared in `HIGHLIGHT_COLOR_TOKENS`. Core roles are grouped into **Local states** (`current`, `frontier`, `queued`, `visited`) and **Global overlays** (`start`, `goal`, `path-active`, `path-final`, `obstacle`).
+- Plugins that introduce additional highlight roles must extend `HIGHLIGHT_COLOR_TOKENS` **and** pass `legend` groups to the panel so all colors remain documented in the UI.
+- When reusing existing roles in specialized ways (e.g., distinguishing multiple frontier queues), document the interpretation in the plugin README but keep the canonical label so learners see consistent terminology across visualizations.
+- Any pull request that modifies highlight colors or roles MUST include corresponding updates to the legend test coverage (`tests/unit/panels/LegendPanel.test.ts`).
+
 ---
 
 For questions or proposals to extend the palette, open an issue referencing this file.

--- a/src/lib/components/panels/LegendPanel.svelte
+++ b/src/lib/components/panels/LegendPanel.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+        import type { LegendGroup } from '$lib/types';
+        import { createLegendGroups, type LegendDisplayGroup } from './legendConfig';
+
+        interface Props {
+                extraGroups?: LegendGroup[];
+        }
+
+        let { extraGroups = [] }: Props = $props();
+        let groups: LegendDisplayGroup[] = $derived.by(() => createLegendGroups(extraGroups));
+</script>
+
+<div class="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-slate-200/80 dark:border-slate-700/80">
+        <div class="px-5 py-4 border-b border-slate-200/80 dark:border-slate-700/80">
+                <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Legend</h2>
+                <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
+                        Color key for highlights applied to the visualization.
+                </p>
+        </div>
+        <div class="px-5 py-4 space-y-6">
+                {#each groups as group (group.title)}
+                        <section class="space-y-3">
+                                <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                        {group.title}
+                                </h3>
+                                <ul class="space-y-3">
+                                        {#each group.items as item (item.role)}
+                                                <li class="flex items-start gap-3" data-testid={`legend-item-${item.role}`}>
+                                                        <span
+                                                                class={`mt-0.5 h-8 w-8 shrink-0 rounded-md border border-slate-300/80 dark:border-slate-600/80 ring-2 ring-offset-2 ring-offset-white dark:ring-offset-slate-900 ${item.tokens.fill} ${item.tokens.border}`}
+                                                                aria-hidden="true"
+                                                                data-testid={`legend-swatch-${item.role}`}
+                                                        ></span>
+                                                        <div class="min-w-0 space-y-1">
+                                                                <p
+                                                                        class={`text-sm font-medium leading-tight ${item.tokens.text}`}
+                                                                        data-testid={`legend-label-${item.role}`}
+                                                                >
+                                                                        {item.label}
+                                                                </p>
+                                                                {#if item.description}
+                                                                        <p class="text-xs text-slate-600 dark:text-slate-400 leading-snug">
+                                                                                {item.description}
+                                                                        </p>
+                                                                {/if}
+                                                        </div>
+                                                </li>
+                                        {/each}
+                                </ul>
+                        </section>
+                {/each}
+        </div>
+</div>

--- a/src/lib/components/panels/LegendPanel.svelte
+++ b/src/lib/components/panels/LegendPanel.svelte
@@ -62,7 +62,7 @@
                                                                 ></span>
                                                                 <div class="min-w-0 space-y-0.5">
                                                                         <p
-                                                                                class={`text-xs font-medium leading-snug ${item.tokens.text}`}
+                                                                                class="text-xs font-medium leading-snug text-slate-700 dark:text-slate-200"
                                                                                 data-testid={`legend-label-${item.role}`}
                                                                         >
                                                                                 {item.label}

--- a/src/lib/components/panels/LegendPanel.svelte
+++ b/src/lib/components/panels/LegendPanel.svelte
@@ -1,13 +1,16 @@
 <script lang="ts">
-        import type { LegendGroup } from '$lib/types';
+        import type { HighlightRole, LegendGroup } from '$lib/types';
         import { createLegendGroups, type LegendDisplayGroup } from './legendConfig';
 
         interface Props {
                 extraGroups?: LegendGroup[];
+                activeRoles?: HighlightRole[];
         }
 
-        let { extraGroups = [] }: Props = $props();
-        let groups: LegendDisplayGroup[] = $derived.by(() => createLegendGroups(extraGroups));
+        let { extraGroups = [], activeRoles }: Props = $props();
+        let groups: LegendDisplayGroup[] = $derived.by(() =>
+                createLegendGroups({ extraGroups, activeRoles })
+        );
         let isCollapsed = $state(false);
 
         function toggleCollapse() {

--- a/src/lib/components/panels/LegendPanel.svelte
+++ b/src/lib/components/panels/LegendPanel.svelte
@@ -8,46 +8,76 @@
 
         let { extraGroups = [] }: Props = $props();
         let groups: LegendDisplayGroup[] = $derived.by(() => createLegendGroups(extraGroups));
+        let isCollapsed = $state(false);
+
+        function toggleCollapse() {
+                isCollapsed = !isCollapsed;
+        }
 </script>
 
-<div class="bg-white dark:bg-gray-900 rounded-lg shadow-sm border border-slate-200/80 dark:border-slate-700/80">
-        <div class="px-5 py-4 border-b border-slate-200/80 dark:border-slate-700/80">
-                <h2 class="text-base font-semibold text-slate-800 dark:text-slate-100">Legend</h2>
-                <p class="mt-1 text-sm text-slate-600 dark:text-slate-400">
-                        Color key for highlights applied to the visualization.
-                </p>
-        </div>
-        <div class="px-5 py-4 space-y-6">
-                {#each groups as group (group.title)}
-                        <section class="space-y-3">
-                                <h3 class="text-xs font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
-                                        {group.title}
-                                </h3>
-                                <ul class="space-y-3">
-                                        {#each group.items as item (item.role)}
-                                                <li class="flex items-start gap-3" data-testid={`legend-item-${item.role}`}>
-                                                        <span
-                                                                class={`mt-0.5 h-8 w-8 shrink-0 rounded-md border border-slate-300/80 dark:border-slate-600/80 ring-2 ring-offset-2 ring-offset-white dark:ring-offset-slate-900 ${item.tokens.fill} ${item.tokens.border}`}
-                                                                aria-hidden="true"
-                                                                data-testid={`legend-swatch-${item.role}`}
-                                                        ></span>
-                                                        <div class="min-w-0 space-y-1">
-                                                                <p
-                                                                        class={`text-sm font-medium leading-tight ${item.tokens.text}`}
-                                                                        data-testid={`legend-label-${item.role}`}
-                                                                >
-                                                                        {item.label}
-                                                                </p>
-                                                                {#if item.description}
-                                                                        <p class="text-xs text-slate-600 dark:text-slate-400 leading-snug">
-                                                                                {item.description}
+<section class="bg-white dark:bg-gray-900 rounded-md border border-slate-200/70 dark:border-slate-700/70 shadow-sm">
+        <header class="flex items-start justify-between gap-3 px-4 py-3">
+                <div>
+                        <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-100">Legend</h2>
+                        <p class="text-xs text-slate-600 dark:text-slate-400">
+                                Color key for highlights applied to the visualization.
+                        </p>
+                </div>
+                <button
+                        type="button"
+                        class="inline-flex items-center gap-1 rounded-md border border-transparent bg-slate-100/60 dark:bg-slate-800/60 px-2 py-1 text-xs font-medium text-slate-700 dark:text-slate-200 hover:bg-slate-200/70 dark:hover:bg-slate-700/70 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400"
+                        aria-expanded={!isCollapsed}
+                        on:click={toggleCollapse}
+                >
+                        <span>{isCollapsed ? 'Show' : 'Hide'}</span>
+                        <svg
+                                class={`h-3 w-3 transition-transform ${isCollapsed ? '' : 'rotate-180'}`}
+                                viewBox="0 0 20 20"
+                                fill="currentColor"
+                                aria-hidden="true"
+                        >
+                                <path
+                                        fill-rule="evenodd"
+                                        d="M5.23 7.21a.75.75 0 0 1 1.06.02L10 11.084l3.71-3.854a.75.75 0 1 1 1.08 1.04l-4.24 4.4a.75.75 0 0 1-1.08 0l-4.24-4.4a.75.75 0 0 1 .02-1.06Z"
+                                        clip-rule="evenodd"
+                                />
+                        </svg>
+                </button>
+        </header>
+
+        {#if !isCollapsed}
+                <div class="px-4 pb-4 space-y-4">
+                        {#each groups as group (group.title)}
+                                <section class="space-y-2">
+                                        <h3 class="text-[0.65rem] font-semibold uppercase tracking-wide text-slate-500 dark:text-slate-400">
+                                                {group.title}
+                                        </h3>
+                                        <ul class="grid gap-3 sm:grid-cols-2">
+                                                {#each group.items as item (item.role)}
+                                                        <li class="flex items-center gap-2" data-testid={`legend-item-${item.role}`}>
+                                                                <span
+                                                                        class={`h-5 w-5 shrink-0 rounded-md border border-slate-300/80 dark:border-slate-600/80 ring-1 ring-inset ring-slate-900/5 dark:ring-white/10 ${item.tokens.fill} ${item.tokens.border}`}
+                                                                        aria-hidden="true"
+                                                                        data-testid={`legend-swatch-${item.role}`}
+                                                                ></span>
+                                                                <div class="min-w-0 space-y-0.5">
+                                                                        <p
+                                                                                class={`text-xs font-medium leading-snug ${item.tokens.text}`}
+                                                                                data-testid={`legend-label-${item.role}`}
+                                                                        >
+                                                                                {item.label}
                                                                         </p>
-                                                                {/if}
-                                                        </div>
-                                                </li>
-                                        {/each}
-                                </ul>
-                        </section>
-                {/each}
-        </div>
-</div>
+                                                                        {#if item.description}
+                                                                                <p class="text-[0.68rem] leading-tight text-slate-600 dark:text-slate-400">
+                                                                                        {item.description}
+                                                                                </p>
+                                                                        {/if}
+                                                                </div>
+                                                        </li>
+                                                {/each}
+                                        </ul>
+                                </section>
+                        {/each}
+                </div>
+        {/if}
+</section>

--- a/src/lib/components/panels/legendConfig.ts
+++ b/src/lib/components/panels/legendConfig.ts
@@ -1,0 +1,96 @@
+import { HIGHLIGHT_COLOR_TOKENS, type HighlightTokens } from '$lib/theme/colorTokens';
+import type { HighlightRole, LegendGroup, LegendItem } from '$lib/types';
+
+const ROLE_LABELS: Record<HighlightRole, LegendItem> = {
+        start: { role: 'start', label: 'Start node' },
+        goal: { role: 'goal', label: 'Goal node' },
+        current: { role: 'current', label: 'Current focus' },
+        frontier: { role: 'frontier', label: 'Frontier candidate' },
+        queued: { role: 'queued', label: 'Queued for expansion' },
+        visited: { role: 'visited', label: 'Visited / closed' },
+        'path-active': {
+                role: 'path-active',
+                label: 'Shortest path (exploring)',
+                description: 'Edges or cells under evaluation'
+        },
+        'path-final': {
+                role: 'path-final',
+                label: 'Shortest path (confirmed)',
+                description: 'Final answer or committed route'
+        },
+        obstacle: { role: 'obstacle', label: 'Obstacle / wall' },
+        'weight-peek': {
+                role: 'weight-peek',
+                label: 'Weight peek',
+                description: 'Temporary cost or heuristic comparison'
+        },
+        auxiliary: {
+                role: 'auxiliary',
+                label: 'Auxiliary marker',
+                description: 'Helper overlay supplied by the plugin'
+        }
+};
+
+export const BASE_LEGEND_GROUPS: LegendGroup[] = [
+        {
+                title: 'Local states',
+                items: [
+                        ROLE_LABELS.current,
+                        ROLE_LABELS.frontier,
+                        ROLE_LABELS.queued,
+                        ROLE_LABELS.visited
+                ]
+        },
+        {
+                title: 'Global overlays',
+                items: [
+                        ROLE_LABELS.start,
+                        ROLE_LABELS.goal,
+                        ROLE_LABELS['path-active'],
+                        ROLE_LABELS['path-final'],
+                        ROLE_LABELS.obstacle
+                ]
+        },
+        {
+                title: 'Supplementary overlays',
+                items: [ROLE_LABELS['weight-peek'], ROLE_LABELS.auxiliary]
+        }
+];
+
+export interface LegendDisplayItem extends LegendItem {
+        tokens: HighlightTokens;
+}
+
+export interface LegendDisplayGroup {
+        title: string;
+        items: LegendDisplayItem[];
+}
+
+function attachTokens(items: LegendItem[]): LegendDisplayItem[] {
+        return items
+                .map((item) => {
+                        const tokens = HIGHLIGHT_COLOR_TOKENS[item.role];
+                        if (!tokens) return null;
+
+                        return {
+                                ...item,
+                                tokens
+                        } satisfies LegendDisplayItem;
+                })
+                .filter((entry): entry is LegendDisplayItem => Boolean(entry));
+}
+
+export function createLegendGroups(extraGroups: LegendGroup[] = []): LegendDisplayGroup[] {
+        const sanitizedExtraGroups = extraGroups.map((group) => ({
+                title: group.title,
+                items: attachTokens(group.items)
+        }));
+
+        return [
+                ...BASE_LEGEND_GROUPS.map((group) => ({
+                        title: group.title,
+                        items: attachTokens(group.items)
+                })),
+                ...sanitizedExtraGroups
+        ];
+}

--- a/src/lib/components/panels/legendConfig.ts
+++ b/src/lib/components/panels/legendConfig.ts
@@ -1,33 +1,61 @@
 import { HIGHLIGHT_COLOR_TOKENS, type HighlightTokens } from '$lib/theme/colorTokens';
-import type { HighlightRole, LegendGroup, LegendItem } from '$lib/types';
+import { HIGHLIGHT_ROLES, type HighlightRole, type LegendGroup, type LegendItem } from '$lib/types';
 
 const ROLE_LABELS: Record<HighlightRole, LegendItem> = {
-        start: { role: 'start', label: 'Start node' },
-        goal: { role: 'goal', label: 'Goal node' },
-        current: { role: 'current', label: 'Current focus' },
-        frontier: { role: 'frontier', label: 'Frontier candidate' },
-        queued: { role: 'queued', label: 'Queued for expansion' },
-        visited: { role: 'visited', label: 'Visited / closed' },
+        start: {
+                role: 'start',
+                label: 'Start node',
+                description: 'Entry point or initial state for the visualization.'
+        },
+        goal: {
+                role: 'goal',
+                label: 'Goal node',
+                description: 'Target state that terminates the search when reached.'
+        },
+        current: {
+                role: 'current',
+                label: 'Current focus',
+                description: 'Element actively processed on this step.'
+        },
+        frontier: {
+                role: 'frontier',
+                label: 'Frontier candidate',
+                description: 'Discovered but not yet expanded.'
+        },
+        queued: {
+                role: 'queued',
+                label: 'Queued for expansion',
+                description: 'Scheduled in a queue, heap, or stack for future processing.'
+        },
+        visited: {
+                role: 'visited',
+                label: 'Visited / closed',
+                description: 'Explored and removed from the active frontier.'
+        },
         'path-active': {
                 role: 'path-active',
                 label: 'Shortest path (exploring)',
-                description: 'Edges or cells under evaluation'
+                description: 'Edges or cells currently evaluated as part of a candidate path.'
         },
         'path-final': {
                 role: 'path-final',
                 label: 'Shortest path (confirmed)',
-                description: 'Final answer or committed route'
+                description: 'Final answer or committed route.'
         },
-        obstacle: { role: 'obstacle', label: 'Obstacle / wall' },
+        obstacle: {
+                role: 'obstacle',
+                label: 'Obstacle / wall',
+                description: 'Impassable cell or constraint that blocks traversal.'
+        },
         'weight-peek': {
                 role: 'weight-peek',
                 label: 'Weight peek',
-                description: 'Temporary cost or heuristic comparison'
+                description: 'Temporary cost or heuristic comparison.'
         },
         auxiliary: {
                 role: 'auxiliary',
                 label: 'Auxiliary marker',
-                description: 'Helper overlay supplied by the plugin'
+                description: 'Helper overlay supplied by the plugin.'
         }
 };
 
@@ -66,8 +94,31 @@ export interface LegendDisplayGroup {
         items: LegendDisplayItem[];
 }
 
-function attachTokens(items: LegendItem[]): LegendDisplayItem[] {
+export interface CreateLegendGroupOptions {
+        extraGroups?: LegendGroup[];
+        activeRoles?: Iterable<HighlightRole>;
+}
+
+function normalizeRoleFilter(activeRoles?: Iterable<HighlightRole>): Set<HighlightRole> | null {
+        if (!activeRoles) {
+                return null;
+        }
+
+        const validRoles = new Set(HIGHLIGHT_ROLES);
+        const selected = new Set<HighlightRole>();
+        for (const role of activeRoles) {
+                if (validRoles.has(role)) {
+                        selected.add(role);
+                }
+        }
+
+        return selected.size > 0 ? selected : null;
+}
+
+function attachTokens(items: LegendItem[], roleFilter: Set<HighlightRole> | null): LegendDisplayItem[] {
         return items
+                .filter((item) => Boolean(item.description?.trim()))
+                .filter((item) => (roleFilter ? roleFilter.has(item.role) : true))
                 .map((item) => {
                         const tokens = HIGHLIGHT_COLOR_TOKENS[item.role];
                         if (!tokens) return null;
@@ -80,17 +131,24 @@ function attachTokens(items: LegendItem[]): LegendDisplayItem[] {
                 .filter((entry): entry is LegendDisplayItem => Boolean(entry));
 }
 
-export function createLegendGroups(extraGroups: LegendGroup[] = []): LegendDisplayGroup[] {
+export function createLegendGroups({
+        extraGroups = [],
+        activeRoles
+}: CreateLegendGroupOptions = {}): LegendDisplayGroup[] {
+        const roleFilter = normalizeRoleFilter(activeRoles);
+
         const sanitizedExtraGroups = extraGroups.map((group) => ({
                 title: group.title,
-                items: attachTokens(group.items)
+                items: attachTokens(group.items, roleFilter)
         }));
 
         return [
                 ...BASE_LEGEND_GROUPS.map((group) => ({
                         title: group.title,
-                        items: attachTokens(group.items)
+                        items: attachTokens(group.items, roleFilter)
                 })),
                 ...sanitizedExtraGroups
-        ];
+        ].filter((group) => group.items.length > 0);
 }
+
+export { ROLE_LABELS };

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -16,8 +16,10 @@ export { HIGHLIGHT_ROLES } from './plugin';
 export type { GridState } from './state';
 
 export {
-	FrameSchema,
-	TraceSchema,
-	validateTrace,
-	validateFrameSequence
+        FrameSchema,
+        TraceSchema,
+        validateTrace,
+        validateFrameSequence
 } from './validation';
+
+export type { LegendGroup, LegendItem } from './legend';

--- a/src/lib/types/legend.ts
+++ b/src/lib/types/legend.ts
@@ -1,0 +1,12 @@
+import type { HighlightRole } from './plugin';
+
+export interface LegendItem {
+        role: HighlightRole;
+        label: string;
+        description?: string;
+}
+
+export interface LegendGroup {
+        title: string;
+        items: LegendItem[];
+}

--- a/src/lib/types/legend.ts
+++ b/src/lib/types/legend.ts
@@ -3,7 +3,7 @@ import type { HighlightRole } from './plugin';
 export interface LegendItem {
         role: HighlightRole;
         label: string;
-        description?: string;
+        description: string;
 }
 
 export interface LegendGroup {

--- a/src/lib/types/plugin.ts
+++ b/src/lib/types/plugin.ts
@@ -5,6 +5,8 @@
  * Based on contracts/plugin-interface.ts from design docs.
  */
 
+import type { LegendGroup } from './legend';
+
 export const HIGHLIGHT_ROLES = [
         'start',
         'goal',
@@ -74,14 +76,15 @@ export interface ValidationResult {
 }
 
 export interface AlgorithmPlugin<TInput = any, TState = any> {
-	id: string;
-	name: string;
-	description: string;
-	category: string;
-	subcategory?: string; // Feature 004: Optional subcategory for navigation tree
-	visualizationType: 'grid' | 'array' | 'tree' | 'graph';
-	presets: InputPreset<TInput>[];
-	trace(input: TInput): Trace<TState>;
-	validateInput(input: TInput): ValidationResult;
-	code?: CodeDefinition;
+        id: string;
+        name: string;
+        description: string;
+        category: string;
+        subcategory?: string; // Feature 004: Optional subcategory for navigation tree
+        visualizationType: 'grid' | 'array' | 'tree' | 'graph';
+        presets: InputPreset<TInput>[];
+        trace(input: TInput): Trace<TState>;
+        validateInput(input: TInput): ValidationResult;
+        code?: CodeDefinition;
+        legend?: LegendGroup[];
 }

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,12 +1,14 @@
 <script lang="ts">
-	/**
-	 * Home Page (Welcome)
-	 *
-	 * Simplified landing page. Algorithm selection now happens via sidebar navigation.
-	 *
-	 * Feature: 003-move-the-navigation
-	 * Date: 2025-10-06
-	 */
+        /**
+         * Home Page (Welcome)
+         *
+         * Simplified landing page. Algorithm selection now happens via sidebar navigation.
+         *
+         * Feature: 003-move-the-navigation
+         * Date: 2025-10-06
+         */
+
+        import LegendPanel from '$lib/components/panels/LegendPanel.svelte';
 </script>
 
 <svelte:head>
@@ -58,15 +60,15 @@
 			</div>
 		</div>
 
-		<!-- Features -->
-		<div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-6">
-			<div class="text-center space-y-2">
-				<div class="text-4xl">🎯</div>
-				<h3 class="font-semibold">Step-by-Step</h3>
-				<p class="text-sm text-gray-600 dark:text-gray-400">
-					Visualize each step of algorithm execution
-				</p>
-			</div>
+                <!-- Features -->
+                <div class="mt-12 grid grid-cols-1 md:grid-cols-3 gap-6">
+                        <div class="text-center space-y-2">
+                                <div class="text-4xl">🎯</div>
+                                <h3 class="font-semibold">Step-by-Step</h3>
+                                <p class="text-sm text-gray-600 dark:text-gray-400">
+                                        Visualize each step of algorithm execution
+                                </p>
+                        </div>
 			<div class="text-center space-y-2">
 				<div class="text-4xl">⚡</div>
 				<h3 class="font-semibold">Interactive</h3>
@@ -79,8 +81,20 @@
 				<h3 class="font-semibold">Multiple Presets</h3>
 				<p class="text-sm text-gray-600 dark:text-gray-400">
 					Try different inputs to see how algorithms adapt
-				</p>
-			</div>
-		</div>
-	</div>
+                                </p>
+                        </div>
+                </div>
+
+                <!-- Legend preview -->
+                <section class="mt-12 space-y-4">
+                        <div class="space-y-2">
+                                <h2 class="text-2xl font-semibold">Highlight legend</h2>
+                                <p class="text-gray-600 dark:text-gray-400">
+                                        Every visualization keeps this legend in sync so colors always communicate the same
+                                        roles.
+                                </p>
+                        </div>
+                        <LegendPanel />
+                </section>
+        </div>
 </div>

--- a/src/routes/[category]/[algorithm]/+page.svelte
+++ b/src/routes/[category]/[algorithm]/+page.svelte
@@ -12,10 +12,11 @@
 	import type { PageData } from './$types';
 	import { PlaybackController } from '$lib/core/PlaybackController.svelte';
 	import GridRenderer from '$lib/renderers/GridRenderer.svelte';
-	import PlaybackControls from '$lib/components/PlaybackControls.svelte';
-	import SpeedControl from '$lib/components/SpeedControl.svelte';
-	import StatusPanel from '$lib/components/StatusPanel.svelte';
-	import PriorityQueueDisplay from '$lib/components/visualization/PriorityQueueDisplay.svelte';
+        import PlaybackControls from '$lib/components/PlaybackControls.svelte';
+        import SpeedControl from '$lib/components/SpeedControl.svelte';
+        import StatusPanel from '$lib/components/StatusPanel.svelte';
+        import LegendPanel from '$lib/components/panels/LegendPanel.svelte';
+        import PriorityQueueDisplay from '$lib/components/visualization/PriorityQueueDisplay.svelte';
 	import { trappingRainWater2Plugin } from '$lib/plugins/trappingRainWater2';
 	import { uniquePathsWithObstaclesPlugin } from '$lib/plugins/uniquePathsWithObstacles';
 	import { swimInWaterPlugin } from '$lib/plugins/swimInWater';
@@ -33,8 +34,8 @@
 	// Get algorithm plugin based on pluginId from route
 	const algorithm = $derived(pluginMap[data.pluginId as keyof typeof pluginMap]);
 
-	// Playback controller
-	const controller = new PlaybackController();
+        // Playback controller
+        const controller = new PlaybackController();
 
 	// Preset selection state
 	let selectedPresetIndex = $state(0);
@@ -108,8 +109,11 @@
 		algorithm.id === 'swim-in-water' || algorithm.id === 'trapping-rain-water-2'
 	);
 
-	// Load trace when algorithm or preset changes
-	$effect(() => {
+        // Derived legend groups (allow plugins to append extra entries)
+        let legendGroups = $derived(algorithm.legend ?? []);
+
+        // Load trace when algorithm or preset changes
+        $effect(() => {
 		const preset = algorithm.presets[selectedPresetIndex];
 		const validation = algorithm.validateInput(preset.data);
 
@@ -176,10 +180,13 @@
 
 			<!-- Right sidebar -->
 			<div class="space-y-6">
-				<!-- Status Panel -->
-				<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
-					<StatusPanel {controller} />
-				</div>
+                                <!-- Legend -->
+                                <LegendPanel extraGroups={legendGroups} />
+
+                                <!-- Status Panel -->
+                                <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+                                        <StatusPanel {controller} />
+                                </div>
 
 				<!-- Priority Queue Display (conditionally) -->
 				{#if usesPriorityQueue && queueData}

--- a/src/routes/[category]/[algorithm]/+page.svelte
+++ b/src/routes/[category]/[algorithm]/+page.svelte
@@ -10,16 +10,18 @@
 	 */
 
 	import type { PageData } from './$types';
-	import { PlaybackController } from '$lib/core/PlaybackController.svelte';
-	import GridRenderer from '$lib/renderers/GridRenderer.svelte';
+        import { PlaybackController } from '$lib/core/PlaybackController.svelte';
+        import GridRenderer from '$lib/renderers/GridRenderer.svelte';
         import PlaybackControls from '$lib/components/PlaybackControls.svelte';
         import SpeedControl from '$lib/components/SpeedControl.svelte';
         import StatusPanel from '$lib/components/StatusPanel.svelte';
         import LegendPanel from '$lib/components/panels/LegendPanel.svelte';
         import PriorityQueueDisplay from '$lib/components/visualization/PriorityQueueDisplay.svelte';
-	import { trappingRainWater2Plugin } from '$lib/plugins/trappingRainWater2';
-	import { uniquePathsWithObstaclesPlugin } from '$lib/plugins/uniquePathsWithObstacles';
-	import { swimInWaterPlugin } from '$lib/plugins/swimInWater';
+        import { trappingRainWater2Plugin } from '$lib/plugins/trappingRainWater2';
+        import { uniquePathsWithObstaclesPlugin } from '$lib/plugins/uniquePathsWithObstacles';
+        import { swimInWaterPlugin } from '$lib/plugins/swimInWater';
+        import type { HighlightRole, Trace } from '$lib/types';
+        import { HIGHLIGHT_ROLES } from '$lib/types';
 
 	// Props from load function
 	let { data }: { data: PageData } = $props();
@@ -112,16 +114,40 @@
         // Derived legend groups (allow plugins to append extra entries)
         let legendGroups = $derived(algorithm.legend ?? []);
 
+        // Track which highlight roles appear in the active trace
+        let activeLegendRoles = $state<HighlightRole[]>([...HIGHLIGHT_ROLES]);
+
+        function extractLegendRoles(trace: Trace<any>): HighlightRole[] {
+                const roles = new Set<HighlightRole>();
+
+                for (const frame of trace.frames) {
+                        for (const marker of frame.focus ?? []) {
+                                roles.add(marker.role);
+                        }
+                        for (const marker of frame.neighbors ?? []) {
+                                roles.add(marker.role);
+                        }
+                        for (const highlight of frame.globalHighlights ?? []) {
+                                roles.add(highlight.role);
+                        }
+                }
+
+                return [...roles];
+        }
+
         // Load trace when algorithm or preset changes
         $effect(() => {
 		const preset = algorithm.presets[selectedPresetIndex];
 		const validation = algorithm.validateInput(preset.data);
 
-		if (validation.valid) {
-			const trace = algorithm.trace(preset.data);
-			controller.loadTrace(trace);
-		}
-	});
+                if (validation.valid) {
+                        const trace = algorithm.trace(preset.data);
+                        controller.loadTrace(trace);
+                        activeLegendRoles = extractLegendRoles(trace);
+                } else {
+                        activeLegendRoles = [];
+                }
+        });
 
 	function handlePresetChange(index: number) {
 		selectedPresetIndex = index;
@@ -180,7 +206,7 @@
                                 </div>
 
                                 <!-- Legend -->
-                                <LegendPanel extraGroups={legendGroups} />
+                                <LegendPanel extraGroups={legendGroups} activeRoles={activeLegendRoles} />
                         </div>
 
                         <!-- Right sidebar -->

--- a/src/routes/[category]/[algorithm]/+page.svelte
+++ b/src/routes/[category]/[algorithm]/+page.svelte
@@ -172,23 +172,25 @@
 		</div>
 
 		<!-- Main content -->
-		<div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
-			<!-- Visualization -->
-			<div class="lg:col-span-2 bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
-				<GridRenderer frame={controller.currentFrame} heightMap={gridData} mode={gridMode} />
-			</div>
+                <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                        <!-- Visualization -->
+                        <div class="lg:col-span-2 space-y-4">
+                                <div class="bg-white dark:bg-gray-800 rounded-lg shadow overflow-hidden">
+                                        <GridRenderer frame={controller.currentFrame} heightMap={gridData} mode={gridMode} />
+                                </div>
 
-			<!-- Right sidebar -->
-			<div class="space-y-6">
                                 <!-- Legend -->
                                 <LegendPanel extraGroups={legendGroups} />
+                        </div>
 
+                        <!-- Right sidebar -->
+                        <div class="space-y-6">
                                 <!-- Status Panel -->
                                 <div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
                                         <StatusPanel {controller} />
                                 </div>
 
-				<!-- Priority Queue Display (conditionally) -->
+                                <!-- Priority Queue Display (conditionally) -->
 				{#if usesPriorityQueue && queueData}
 					<PriorityQueueDisplay items={queueData.items} remainingCount={queueData.remainingCount} />
 				{/if}

--- a/tests/unit/panels/LegendPanel.test.ts
+++ b/tests/unit/panels/LegendPanel.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, it } from 'vitest';
 import { createLegendGroups } from '$lib/components/panels/legendConfig';
 import { HIGHLIGHT_COLOR_TOKENS } from '$lib/theme/colorTokens';
-import type { HighlightRole } from '$lib/types';
+import type { HighlightRole, LegendGroup } from '$lib/types';
 
 const splitClasses = (value: string) => value.split(/\s+/).filter(Boolean);
 
 describe('LegendPanel', () => {
-        it('renders every highlight role with the expected classes', () => {
+        it('renders every highlight role with the expected classes when no filter is provided', () => {
                 const groups = createLegendGroups();
 
                 const roles = Object.keys(HIGHLIGHT_COLOR_TOKENS) as HighlightRole[];
+                const renderedRoles = groups.flatMap((group) => group.items.map((item) => item.role));
+
+                expect(new Set(renderedRoles)).toEqual(new Set(roles));
+
                 for (const role of roles) {
                         const displayItem = groups
                                 .flatMap((group) => group.items)
@@ -28,5 +32,41 @@ describe('LegendPanel', () => {
                                 expect(splitClasses(displayItem!.tokens.text).includes(className)).toBe(true);
                         }
                 }
+        });
+
+        it('filters legend entries to the provided active roles', () => {
+                const activeRoles: HighlightRole[] = ['current', 'goal', 'visited'];
+                const groups = createLegendGroups({ activeRoles });
+
+                const renderedRoles = groups.flatMap((group) => group.items.map((item) => item.role));
+
+                expect(new Set(renderedRoles)).toEqual(new Set(activeRoles));
+        });
+
+        it('filters extra legend groups by active roles and removes empty groups', () => {
+                const extraGroups: LegendGroup[] = [
+                        {
+                                title: 'Custom overlays',
+                                items: [
+                                        {
+                                                role: 'auxiliary',
+                                                label: 'Auxiliary marker',
+                                                description: 'Helper overlay supplied by the plugin.'
+                                        },
+                                        {
+                                                role: 'queued',
+                                                label: 'Queued for expansion',
+                                                description: 'Scheduled in a queue, heap, or stack for future processing.'
+                                        }
+                                ]
+                        }
+                ];
+
+                const groups = createLegendGroups({ activeRoles: ['auxiliary'], extraGroups });
+
+                expect(groups.every((group) => group.items.length > 0)).toBe(true);
+                const renderedRoles = groups.flatMap((group) => group.items.map((item) => item.role));
+                expect(new Set(renderedRoles)).toEqual(new Set(['auxiliary']));
+                expect(renderedRoles.filter((role) => role === 'queued').length).toBe(0);
         });
 });

--- a/tests/unit/panels/LegendPanel.test.ts
+++ b/tests/unit/panels/LegendPanel.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { createLegendGroups } from '$lib/components/panels/legendConfig';
+import { HIGHLIGHT_COLOR_TOKENS } from '$lib/theme/colorTokens';
+import type { HighlightRole } from '$lib/types';
+
+const splitClasses = (value: string) => value.split(/\s+/).filter(Boolean);
+
+describe('LegendPanel', () => {
+        it('renders every highlight role with the expected classes', () => {
+                const groups = createLegendGroups();
+
+                const roles = Object.keys(HIGHLIGHT_COLOR_TOKENS) as HighlightRole[];
+                for (const role of roles) {
+                        const displayItem = groups
+                                .flatMap((group) => group.items)
+                                .find((item) => item.role === role);
+
+                        expect(displayItem, `Expected legend item for role "${role}"`).toBeDefined();
+
+                        const tokens = HIGHLIGHT_COLOR_TOKENS[role];
+                        for (const className of splitClasses(tokens.fill)) {
+                                expect(splitClasses(displayItem!.tokens.fill).includes(className)).toBe(true);
+                        }
+                        for (const className of splitClasses(tokens.border)) {
+                                expect(splitClasses(displayItem!.tokens.border).includes(className)).toBe(true);
+                        }
+                        for (const className of splitClasses(tokens.text)) {
+                                expect(splitClasses(displayItem!.tokens.text).includes(className)).toBe(true);
+                        }
+                }
+        });
+});


### PR DESCRIPTION
## Summary
- add a reusable LegendPanel component that groups highlight roles and exposes extra slots for plugin-provided legend items
- wire the legend into the home page and algorithm route while extending the plugin contract for optional legend groups
- backfill Vitest coverage for highlight tokens and document the synchronization requirements in the visual encoding spec

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e57be80fb083269211c35c625ee573