### PR TITLE
Add brewing pipeline visualization for LeetCode 3494

### DIFF
--- a/specs/005-new-algorithm-visualization/min-time-to-brew-potions.md
+++ b/specs/005-new-algorithm-visualization/min-time-to-brew-potions.md
@@ -1,0 +1,101 @@
+# Feature Specification: Minimum Time to Brew Potions Visualization
+
+**Feature Branch**: `005-new-algorithm-visualization`
+**Created**: 2025-10-10
+**Status**: Draft (implementation in progress)
+**Input**: Add visualization for LeetCode 3494 "Find the Minimum Amount of Time to Brew Potions"
+
+## Execution Flow (main)
+```
+1. Capture user ask → Visualize LeetCode 3494 brewing pipeline ✓
+2. Identify core concepts → Wizard line, potion batches, synchronized hand-offs ✓
+3. Clarify requirements → Timeline grid, waiting time explanations, constitution alignment ✓
+4. Define user stories & acceptance tests ✓
+5. Enumerate functional requirements ✓
+6. List primary entities & data contracts ✓
+7. Review for completeness ✓
+8. Return spec → READY FOR BUILD ✓
+```
+
+---
+
+## ⚡ Quick Guidelines
+- ✅ Emphasize learning goals over raw code
+- ✅ Keep requirements technology-agnostic
+- ❌ No implementation details (components, files, frameworks)
+- 👥 Target: product & curriculum stakeholders
+
+---
+
+## Clarifications
+
+### Session 2025-10-10
+- **Navigation placement?** Dynamic Programming ▸ Scheduling & Pipelines
+- **Visualization form factor?** 2D grid (wizards × potions) with timeline overlays, highlight wait states per Visual Encoding spec
+- **What insights must be surfaced?** Start/finish timestamps, blocking resource (wizard busy vs potion arrival), running total makespan
+- **How many presets?** Minimum three: problem example, balanced lab (3×3), bottleneck case highlighting idle time chains
+- **Custom input bounds?** ≤ 12 wizards, ≤ 12 potions (≤ 144 cells) to keep traces performant and legible per constitution §V
+- **Legend needs?** Reuse existing roles (`start`, `current`, `path-active`, `visited`, `goal`) with clear descriptions in copy; no new tokens required
+
+---
+
+## User Scenarios & Testing
+
+### Primary Story
+A learner exploring production scheduling wants to see how potion batches flow through wizards with varying skills. They open the visualization, pick the LeetCode sample preset, and observe the exact wait times that force the optimal 110-minute makespan. They step through each wizard hand-off to understand how blocking propagates down the line.
+
+### Acceptance Scenarios
+1. **Given** the learner loads the page, **When** they start playback, **Then** each wizard/potion cell highlights sequentially with start/finish timestamps in the status copy.
+2. **Given** a potion is delayed by a busy wizard, **When** that step renders, **Then** the description explains the wait reason (wizard occupied vs potion still in transit) and the wait duration.
+3. **Given** all wizards finish a potion, **When** the next potion begins, **Then** the timeline respects synchronous hand-off (no overlapping work) and the learner can verify this by inspecting the timestamps.
+4. **Given** playback reaches the final cell, **When** it completes, **Then** the visualization surfaces the total brewing time and marks the pipeline goal state.
+5. **Given** the learner inputs custom skills/mana (within bounds), **When** they submit, **Then** the system validates lengths, numeric ranges (≥1), and cell limit, producing a new trace or human-readable errors.
+
+### Edge Cases
+- Single wizard or single potion (degenerates to simple sum) — ensure timeline still renders sequentially.
+- Equal skills/mana arrays (uniform throughput) — confirm zero waiting except initial alignment.
+- Highly imbalanced wizard skill (slow wizard bottleneck) — ensure idle time preceding the bottleneck is explained.
+- Max supported grid (12×12) — trace generation must remain <100 ms (constitution §V) and keep frames readable.
+
+---
+
+## Requirements
+
+### Functional Requirements
+- **FR-001**: Provide a visualization for LeetCode 3494 "Find the Minimum Amount of Time to Brew Potions" within the Dynamic Programming ▸ Scheduling & Pipelines category.
+- **FR-002**: Render a wizard × potion grid where each cell represents one processing task with immutable timeline data (start, finish, duration).
+- **FR-003**: Highlight the active cell (`current`) and its dependencies (`path-active`) following the global visual-encoding specification.
+- **FR-004**: Annotate each frame with descriptive text explaining the timing decision, including wait causes (wizard busy vs potion transit).
+- **FR-005**: Track cumulative makespan and surface it in both frame metrics and the final completion message.
+- **FR-006**: Mark the first cell as `start` and the final cell as `goal` throughout playback so learners can orient themselves quickly.
+- **FR-007**: Offer at least three presets (problem sample, balanced 3×3, bottleneck) and allow custom input within validated bounds (≤12×12, skills/mana ≥1 integers).
+- **FR-008**: Reject inputs exceeding the visualization bounds or containing non-positive / non-integer values with actionable error messages.
+- **FR-009**: Generate traces that support bidirectional playback without mutating prior frames (immutable frame snapshots).
+- **FR-010**: Ensure legend entries align with existing highlight roles; if additional roles are required, document and extend shared legend assets simultaneously.
+
+### Key Entities
+- **Wizard**: Worker with fixed `skill` multiplier determining processing duration per potion.
+- **Potion Batch**: Sequenced tasks defined by `mana` capacity; flows through wizards in order.
+- **Timeline Cell**: Combination of wizard + potion with immutable start, finish, duration, wait metadata.
+- **Availability Vector**: Captures when each wizard becomes free for the next potion; drives synchronization logic.
+- **Execution Trace**: Ordered frames showing timeline updates, highlights, descriptions, and metrics.
+- **Preset Configuration**: Named scenario bundling `skill`, `mana`, and legend-ready descriptions.
+
+---
+
+## Review & Acceptance Checklist
+- [x] Requirements map back to learner outcomes and constitutional principles.
+- [x] Visual encoding references follow master spec color/token language.
+- [x] Edge cases documented with explicit success criteria.
+- [x] Input bounds justified against performance requirements.
+- [x] No pending clarifications; stakeholders can sign off.
+
+---
+
+## Execution Status
+- [x] User intent captured
+- [x] Concept clarification complete
+- [x] Requirements enumerated
+- [x] User stories defined
+- [x] Checklist satisfied
+- [x] Ready for implementation

--- a/src/lib/data/navigation-tree.ts
+++ b/src/lib/data/navigation-tree.ts
@@ -29,22 +29,36 @@ export const navigationTree: NavigationTree = {
 			id: 'dynamic-programming',
 			label: 'Dynamic Programming',
 			children: [
-				{
-					type: 'category',
-					id: 'dp-2d-array',
-					label: '2D Array',
-					children: [
-						{
-							type: 'algorithm',
-							id: 'trapping-rain-water-2',
-							label: 'Trapping Rain Water II',
-							pluginId: 'trapping-rain-water-2',
-							path: '/dynamic-programming/trapping-rain-water-2'
-						}
-					]
-				}
-			]
-		},
+                                {
+                                        type: 'category',
+                                        id: 'dp-2d-array',
+                                        label: '2D Array',
+                                        children: [
+                                                {
+                                                        type: 'algorithm',
+                                                        id: 'trapping-rain-water-2',
+                                                        label: 'Trapping Rain Water II',
+                                                        pluginId: 'trapping-rain-water-2',
+                                                        path: '/dynamic-programming/trapping-rain-water-2'
+                                                }
+                                        ]
+                                },
+                                {
+                                        type: 'category',
+                                        id: 'dp-scheduling',
+                                        label: 'Scheduling & Pipelines',
+                                        children: [
+                                                {
+                                                        type: 'algorithm',
+                                                        id: 'min-time-to-brew-potions',
+                                                        label: 'Minimum Time to Brew Potions',
+                                                        pluginId: 'min-time-to-brew-potions',
+                                                        path: '/dynamic-programming/min-time-to-brew-potions'
+                                                }
+                                        ]
+                                }
+                        ]
+                },
 		{
 			type: 'category',
 			id: 'graphs',

--- a/src/lib/plugins/minTimeToBrewPotions.test.ts
+++ b/src/lib/plugins/minTimeToBrewPotions.test.ts
@@ -71,6 +71,14 @@ describe('minTimeToBrewPotionsPlugin', () => {
                         expect(trace.frames.length).toBeGreaterThanOrEqual(expectedMinimumFrames);
                 });
 
+                it('renders the base grid as duration (skill × mana) costs instead of zero placeholders', () => {
+                        const trace = minTimeToBrewPotionsPlugin.trace(sampleInput);
+                        const firstFrame = trace.frames[0];
+
+                        expect(firstFrame.state?.grid?.[0]?.[0]).toBe(5);
+                        expect(firstFrame.state?.grid?.[1]?.[3]).toBe(10);
+                });
+
                 it('records finish times in the dp matrix', () => {
                         const trace = minTimeToBrewPotionsPlugin.trace(sampleInput);
                         const lastProcessingFrame = trace.frames.at(-2);

--- a/src/lib/plugins/minTimeToBrewPotions.test.ts
+++ b/src/lib/plugins/minTimeToBrewPotions.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { minTimeToBrewPotionsPlugin } from './minTimeToBrewPotions';
+import { TraceSchema, validateFrameSequence } from '$lib/types/validation';
+
+describe('minTimeToBrewPotionsPlugin', () => {
+        describe('validateInput', () => {
+                it('accepts a well-formed configuration', () => {
+                        const result = minTimeToBrewPotionsPlugin.validateInput({
+                                skill: [1, 5, 2, 4],
+                                mana: [5, 1, 4, 2]
+                        });
+
+                        expect(result.valid).toBe(true);
+                });
+
+                it('rejects empty skill array', () => {
+                        const result = minTimeToBrewPotionsPlugin.validateInput({
+                                skill: [],
+                                mana: [1]
+                        });
+
+                        expect(result.valid).toBe(false);
+                        expect(result.errors).toContain('Skill array must contain at least one wizard');
+                });
+
+                it('rejects non-positive values', () => {
+                        const result = minTimeToBrewPotionsPlugin.validateInput({
+                                skill: [2, 0],
+                                mana: [3, -1]
+                        });
+
+                        expect(result.valid).toBe(false);
+                        expect(result.errors).toContain('Skill[1] must be a positive integer');
+                        expect(result.errors).toContain('Mana[1] must be a positive integer');
+                });
+
+                it('rejects instances exceeding visualization bounds', () => {
+                        const result = minTimeToBrewPotionsPlugin.validateInput({
+                                skill: Array(13).fill(1),
+                                mana: [1]
+                        });
+
+                        expect(result.valid).toBe(false);
+                        expect(result.errors?.some((message) => message.includes('at most 12 wizards'))).toBe(true);
+                });
+        });
+
+        describe('trace', () => {
+                const sampleInput = {
+                        skill: [1, 5, 2, 4],
+                        mana: [5, 1, 4, 2],
+                        grid: Array.from({ length: 4 }, () => Array(4).fill(0))
+                };
+
+                it('produces a valid trace for the LeetCode sample (total = 110)', () => {
+                        const trace = minTimeToBrewPotionsPlugin.trace(sampleInput);
+
+                        expect(() => TraceSchema.parse(trace)).not.toThrow();
+                        expect(validateFrameSequence(trace.frames)).toBe(true);
+                        expect(trace.completed).toBe(true);
+                        expect(trace.totalSteps).toBe(trace.frames.length);
+
+                        const finalFrame = trace.frames[trace.frames.length - 1];
+                        expect(finalFrame.metrics?.['Total Time']).toBe(110);
+                        expect(trace.metadata?.totalTime).toBe(110);
+                });
+
+                it('emits one frame per wizard/potion cell plus bookends', () => {
+                        const trace = minTimeToBrewPotionsPlugin.trace(sampleInput);
+                        const expectedMinimumFrames = sampleInput.skill.length * sampleInput.mana.length + 2; // intro + summary
+                        expect(trace.frames.length).toBeGreaterThanOrEqual(expectedMinimumFrames);
+                });
+
+                it('records finish times in the dp matrix', () => {
+                        const trace = minTimeToBrewPotionsPlugin.trace(sampleInput);
+                        const lastProcessingFrame = trace.frames.at(-2);
+                        expect(lastProcessingFrame?.state?.dp?.[3]?.[3]).toBe(110);
+                });
+
+                it('always highlights the start and goal cells', () => {
+                        const trace = minTimeToBrewPotionsPlugin.trace(sampleInput);
+                        const startId = '0,0';
+                        const goalId = '3,3';
+
+                        trace.frames.forEach((frame) => {
+                                const roles = frame.globalHighlights ?? [];
+                                const startHighlight = roles.find((entry) => entry.role === 'start');
+                                const goalHighlight = roles.find((entry) => entry.role === 'goal');
+                                expect(startHighlight?.nodes).toContain(startId);
+                                expect(goalHighlight?.nodes).toContain(goalId);
+                        });
+                });
+        });
+});

--- a/src/lib/plugins/minTimeToBrewPotions.ts
+++ b/src/lib/plugins/minTimeToBrewPotions.ts
@@ -13,7 +13,11 @@ import type { GridState } from '$lib/types/state';
 export interface BrewingInput {
         skill: number[];
         mana: number[];
-        /** Optional helper grid for renderer sizing (derived automatically if omitted) */
+        /**
+         * Optional helper grid for renderer sizing. The visualization overwrites
+         * the values with duration (skill × mana) pairs so viewers see the base
+         * processing cost rather than placeholder zeroes.
+         */
         grid?: number[][];
 }
 
@@ -52,14 +56,10 @@ function cloneMatrix<T>(matrix: T[][]): T[][] {
         return matrix.map((row) => [...row]);
 }
 
-function ensureGrid(input: BrewingInput): number[][] {
-        if (Array.isArray(input.grid) && input.grid.length > 0 && Array.isArray(input.grid[0])) {
-                return cloneMatrix(input.grid);
-        }
-
-        const n = input.skill.length;
-        const m = input.mana.length;
-        return Array.from({ length: n }, () => Array(m).fill(0));
+function buildDurationGrid(skill: number[], mana: number[]): number[][] {
+        return Array.from({ length: skill.length }, (_, wizardIndex) =>
+                Array.from({ length: mana.length }, (_, potionIndex) => skill[wizardIndex] * mana[potionIndex])
+        );
 }
 
 function validateInput(input: BrewingInput): ValidationResult {
@@ -157,10 +157,8 @@ function trace(input: BrewingInput): Trace<BrewingState> {
         const n = skill.length;
         const m = mana.length;
 
-        const durations = Array.from({ length: n }, (_, i) =>
-                Array.from({ length: m }, (_, j) => skill[i] * mana[j])
-        );
-        const grid = ensureGrid(input);
+        const durations = buildDurationGrid(skill, mana);
+        const grid = buildDurationGrid(skill, mana);
         const visited = Array.from({ length: n }, () => Array(m).fill(false));
         const dpMatrix = Array.from({ length: n }, () => Array<(number | null)>(m).fill(null));
         const startTimes = Array.from({ length: n }, () => Array<(number | null)>(m).fill(null));

--- a/src/lib/plugins/minTimeToBrewPotions.ts
+++ b/src/lib/plugins/minTimeToBrewPotions.ts
@@ -1,0 +1,406 @@
+/**
+ * Minimum Time to Brew Potions Plugin
+ *
+ * Visualization for LeetCode 3494 "Find the Minimum Amount of Time to Brew Potions".
+ * Models the brewing line as a wizard × potion timeline grid and highlights
+ * synchronized hand-offs per project constitution requirements.
+ */
+
+import type { AlgorithmPlugin, Trace, Frame, ValidationResult, InputPreset } from '$lib/types';
+import type { GridState } from '$lib/types/state';
+
+/** Input contract for brewing visualization */
+export interface BrewingInput {
+        skill: number[];
+        mana: number[];
+        /** Optional helper grid for renderer sizing (derived automatically if omitted) */
+        grid?: number[][];
+}
+
+/** Extended grid state containing timing metadata */
+export interface BrewingState extends GridState {
+        /** Finish times displayed in DP mode */
+        dp: (number | null)[][];
+        /** Cell start times */
+        startTimes: (number | null)[][];
+        /** Cell finish times */
+        finishTimes: (number | null)[][];
+        /** Wait because wizard was still busy with previous potion */
+        waitForWizard: (number | null)[][];
+        /** Wait because potion was still travelling from previous wizard */
+        waitForPotion: (number | null)[][];
+        /** Active indices for context */
+        currentWizard?: number;
+        currentPotion?: number;
+        /** Current availability of each wizard after this frame */
+        wizardAvailability: number[];
+        /** Running makespan */
+        makespan: number;
+        /** Immutable copies of input arrays for legend/status panels */
+        skillProfile: number[];
+        manaProfile: number[];
+}
+
+const MAX_DIMENSION = 12; // per spec clarification (≤ 12 wizards/potions)
+const MAX_CELLS = 144; // keep traces performant and legible
+
+function isPositiveInteger(value: unknown): value is number {
+        return typeof value === 'number' && Number.isInteger(value) && value > 0;
+}
+
+function cloneMatrix<T>(matrix: T[][]): T[][] {
+        return matrix.map((row) => [...row]);
+}
+
+function ensureGrid(input: BrewingInput): number[][] {
+        if (Array.isArray(input.grid) && input.grid.length > 0 && Array.isArray(input.grid[0])) {
+                return cloneMatrix(input.grid);
+        }
+
+        const n = input.skill.length;
+        const m = input.mana.length;
+        return Array.from({ length: n }, () => Array(m).fill(0));
+}
+
+function validateInput(input: BrewingInput): ValidationResult {
+        const errors: string[] = [];
+
+        if (!input || !Array.isArray(input.skill) || !Array.isArray(input.mana)) {
+                return {
+                        valid: false,
+                        errors: ['Input must include both skill and mana arrays']
+                };
+        }
+
+        const { skill, mana } = input;
+
+        if (skill.length === 0) {
+                errors.push('Skill array must contain at least one wizard');
+        }
+        if (mana.length === 0) {
+                errors.push('Mana array must contain at least one potion');
+        }
+
+        if (skill.length > MAX_DIMENSION) {
+                errors.push(`Visualization supports at most ${MAX_DIMENSION} wizards to preserve clarity`);
+        }
+        if (mana.length > MAX_DIMENSION) {
+                errors.push(`Visualization supports at most ${MAX_DIMENSION} potions to preserve clarity`);
+        }
+
+        if (skill.length * mana.length > MAX_CELLS) {
+                errors.push(`Total wizard × potion combinations must not exceed ${MAX_CELLS}`);
+        }
+
+        skill.forEach((value, index) => {
+                if (!isPositiveInteger(value)) {
+                        errors.push(`Skill[${index}] must be a positive integer`);
+                }
+        });
+
+        mana.forEach((value, index) => {
+                if (!isPositiveInteger(value)) {
+                        errors.push(`Mana[${index}] must be a positive integer`);
+                }
+        });
+
+        return {
+                valid: errors.length === 0,
+                errors: errors.length > 0 ? errors : undefined
+        };
+}
+
+function buildHighlights(startId: string, goalId: string, extra?: { pathFinal?: string[] }): NonNullable<Frame<BrewingState>['globalHighlights']> {
+        const highlights: NonNullable<Frame<BrewingState>['globalHighlights']> = [
+                { role: 'start', nodes: [startId] },
+                { role: 'goal', nodes: [goalId] }
+        ];
+
+        if (extra?.pathFinal && extra.pathFinal.length > 0) {
+                highlights.push({ role: 'path-final', nodes: extra.pathFinal });
+        }
+
+        return highlights;
+}
+
+function trace(input: BrewingInput): Trace<BrewingState> {
+        const validation = validateInput(input);
+        if (!validation.valid) {
+                return {
+                        frames: [
+                                {
+                                        step: 0,
+                                        state: {
+                                                grid: [],
+                                                visited: [],
+                                                dp: [],
+                                                startTimes: [],
+                                                finishTimes: [],
+                                                waitForWizard: [],
+                                                waitForPotion: [],
+                                                wizardAvailability: [],
+                                                makespan: 0,
+                                                skillProfile: input.skill ?? [],
+                                                manaProfile: input.mana ?? []
+                                        },
+                                        description: validation.errors?.join('\n') ?? 'Invalid input'
+                                }
+                        ],
+                        totalSteps: 1,
+                        completed: false,
+                        metadata: { valid: false, errors: validation.errors }
+                };
+        }
+
+        const skill = [...input.skill];
+        const mana = [...input.mana];
+        const n = skill.length;
+        const m = mana.length;
+
+        const durations = Array.from({ length: n }, (_, i) =>
+                Array.from({ length: m }, (_, j) => skill[i] * mana[j])
+        );
+        const grid = ensureGrid(input);
+        const visited = Array.from({ length: n }, () => Array(m).fill(false));
+        const dpMatrix = Array.from({ length: n }, () => Array<(number | null)>(m).fill(null));
+        const startTimes = Array.from({ length: n }, () => Array<(number | null)>(m).fill(null));
+        const finishTimes = Array.from({ length: n }, () => Array<(number | null)>(m).fill(null));
+        const waitForWizard = Array.from({ length: n }, () => Array<(number | null)>(m).fill(null));
+        const waitForPotion = Array.from({ length: n }, () => Array<(number | null)>(m).fill(null));
+
+        const frames: Frame<BrewingState>[] = [];
+        const wizardAvailability = new Array<number>(n).fill(0);
+        const startNodeId = '0,0';
+        const goalNodeId = `${n - 1},${m - 1}`;
+        let step = 0;
+
+        const pushFrame = (options: {
+                state: Partial<BrewingState>;
+                description: string;
+                focus?: Frame<BrewingState>['focus'];
+                neighbors?: Frame<BrewingState>['neighbors'];
+                highlightsExtra?: { pathFinal?: string[] };
+                metrics?: Frame<BrewingState>['metrics'];
+        }) => {
+                frames.push({
+                        step: step++,
+                        state: {
+                                grid: cloneMatrix(grid),
+                                visited: cloneMatrix(visited),
+                                dp: cloneMatrix(dpMatrix),
+                                startTimes: cloneMatrix(startTimes),
+                                finishTimes: cloneMatrix(finishTimes),
+                                waitForWizard: cloneMatrix(waitForWizard),
+                                waitForPotion: cloneMatrix(waitForPotion),
+                                wizardAvailability: [...wizardAvailability],
+                                makespan: wizardAvailability[n - 1] ?? 0,
+                                skillProfile: [...skill],
+                                manaProfile: [...mana],
+                                ...options.state
+                        },
+                        focus: options.focus,
+                        neighbors: options.neighbors,
+                        globalHighlights: buildHighlights(startNodeId, goalNodeId, options.highlightsExtra),
+                        description: options.description,
+                        metrics: options.metrics
+                });
+        };
+
+        pushFrame({
+                state: {},
+                description: `Initialized brewing line with ${n} wizard${n === 1 ? '' : 's'} and ${m} potion${m === 1 ? '' : 's'}. Duration per cell = skill × mana.`,
+                metrics: {
+                        Wizards: n,
+                        Potions: m,
+                        'Max Cells Supported': MAX_CELLS
+                }
+        });
+
+        for (let potionIndex = 0; potionIndex < m; potionIndex++) {
+                const provisionalStarts = new Array<number>(n);
+                const provisionalFinishes = new Array<number>(n);
+                const alignedStarts = new Array<number>(n);
+                const alignedFinishes = new Array<number>(n);
+                const wizardReadySnapshot = new Array<number>(n);
+                let currentFlowTime = 0;
+
+                for (let wizardIndex = 0; wizardIndex < n; wizardIndex++) {
+                        const wizardReadyAt = wizardAvailability[wizardIndex];
+                        wizardReadySnapshot[wizardIndex] = wizardReadyAt;
+                        const start = Math.max(currentFlowTime, wizardReadyAt);
+                        const finish = start + durations[wizardIndex][potionIndex];
+                        provisionalStarts[wizardIndex] = start;
+                        provisionalFinishes[wizardIndex] = finish;
+                        currentFlowTime = finish;
+                }
+
+                alignedFinishes[n - 1] = provisionalFinishes[n - 1];
+                alignedStarts[n - 1] = alignedFinishes[n - 1] - durations[n - 1][potionIndex];
+                for (let wizardIndex = n - 2; wizardIndex >= 0; wizardIndex--) {
+                        const requiredFinish = alignedStarts[wizardIndex + 1];
+                        const finish = Math.max(provisionalFinishes[wizardIndex], requiredFinish);
+                        alignedFinishes[wizardIndex] = finish;
+                        alignedStarts[wizardIndex] = finish - durations[wizardIndex][potionIndex];
+                }
+
+                const availabilityAfterPotion = alignedFinishes.map((value) => value);
+
+                for (let wizardIndex = 0; wizardIndex < n; wizardIndex++) {
+                        const arrivalTime = wizardIndex === 0 ? alignedStarts[0] : alignedFinishes[wizardIndex - 1];
+                        const wizardReadyAt = wizardReadySnapshot[wizardIndex];
+                        const waitWizard = Math.max(0, wizardReadyAt - arrivalTime);
+                        const waitPotionValue = Math.max(0, alignedStarts[wizardIndex] - wizardReadyAt);
+                        const duration = durations[wizardIndex][potionIndex];
+
+                        visited[wizardIndex][potionIndex] = true;
+                        dpMatrix[wizardIndex][potionIndex] = alignedFinishes[wizardIndex];
+                        startTimes[wizardIndex][potionIndex] = alignedStarts[wizardIndex];
+                        finishTimes[wizardIndex][potionIndex] = alignedFinishes[wizardIndex];
+                        waitForWizard[wizardIndex][potionIndex] = waitWizard;
+                        waitForPotion[wizardIndex][potionIndex] = waitPotionValue;
+
+                        const focus = [
+                                { type: 'grid-cell' as const, id: `${wizardIndex},${potionIndex}`, role: 'current' }
+                        ];
+                        const neighbors = [];
+                        if (wizardIndex > 0) {
+                                neighbors.push({
+                                        type: 'grid-cell' as const,
+                                        id: `${wizardIndex - 1},${potionIndex}`,
+                                        role: 'path-active'
+                                });
+                        }
+                        if (potionIndex > 0) {
+                                neighbors.push({
+                                        type: 'grid-cell' as const,
+                                        id: `${wizardIndex},${potionIndex - 1}`,
+                                        role: 'path-active'
+                                });
+                        }
+
+                        const metrics = {
+                                Wizard: wizardIndex,
+                                Potion: potionIndex,
+                                'Skill Multiplier': skill[wizardIndex],
+                                'Mana Capacity': mana[potionIndex],
+                                Duration: duration,
+                                'Arrival Time': arrivalTime,
+                                'Start Time': alignedStarts[wizardIndex],
+                                'Finish Time': alignedFinishes[wizardIndex],
+                                'Wait for Wizard': waitWizard,
+                                'Wait for Potion': waitPotionValue,
+                                'Current Makespan': availabilityAfterPotion[n - 1]
+                        } satisfies Record<string, number>;
+
+                        const waitMessages: string[] = [];
+                        if (waitWizard > 0) {
+                                waitMessages.push(
+                                        `Potion queued ${waitWizard} unit${waitWizard === 1 ? '' : 's'} until wizard became free.`
+                                );
+                        }
+                        if (waitPotionValue > 0) {
+                                waitMessages.push(
+                                        `Wizard idle ${waitPotionValue} unit${waitPotionValue === 1 ? '' : 's'} awaiting potion flow.`
+                                );
+                        }
+
+                        pushFrame({
+                                state: {
+                                        currentWizard: wizardIndex,
+                                        currentPotion: potionIndex,
+                                        wizardAvailability: wizardAvailability.map((value, idx) =>
+                                                idx <= wizardIndex ? availabilityAfterPotion[idx] : value
+                                        ),
+                                        makespan: availabilityAfterPotion[n - 1]
+                                },
+                                focus,
+                                neighbors: neighbors.length > 0 ? neighbors : undefined,
+                                description:
+                                        `Wizard ${wizardIndex} brewing potion ${potionIndex}: start at ${alignedStarts[wizardIndex]} (wizard ready at ${wizardReadyAt}, potion arrival ${arrivalTime}), duration ${duration}, finish at ${alignedFinishes[wizardIndex]}.` +
+                                        (waitMessages.length > 0 ? ` ${waitMessages.join(' ')}` : ' No waiting required.'),
+                                metrics
+                        });
+                }
+
+                for (let wizardIndex = 0; wizardIndex < n; wizardIndex++) {
+                        wizardAvailability[wizardIndex] = availabilityAfterPotion[wizardIndex];
+                }
+        }
+
+        const totalTime = finishTimes[n - 1][m - 1] ?? wizardAvailability[n - 1] ?? 0;
+
+        pushFrame({
+                state: {
+                        makespan: totalTime
+                },
+                description: `All potions brewed. Minimum synchronized completion time = ${totalTime}.`,
+                highlightsExtra: {
+                        pathFinal: Array.from({ length: n * m }, (_, index) => {
+                                const row = Math.floor(index / m);
+                                const col = index % m;
+                                return `${row},${col}`;
+                        })
+                },
+                metrics: {
+                        Wizards: n,
+                        Potions: m,
+                        'Total Time': totalTime
+                }
+        });
+
+        return {
+                frames,
+                totalSteps: frames.length,
+                completed: true,
+                metadata: {
+                        wizards: n,
+                        potions: m,
+                        totalTime,
+                        skill,
+                        mana
+                }
+        };
+}
+
+const presets: InputPreset<BrewingInput>[] = [
+        {
+                name: 'LeetCode Sample',
+                description: 'Example from the problem statement (answer = 110).',
+                data: {
+                        skill: [1, 5, 2, 4],
+                        mana: [5, 1, 4, 2],
+                        grid: Array.from({ length: 4 }, () => Array(4).fill(0))
+                }
+        },
+        {
+                name: 'Balanced Lab',
+                description: 'Three wizards brewing three potions with moderate load.',
+                data: {
+                        skill: [2, 3, 4],
+                        mana: [3, 2, 5],
+                        grid: Array.from({ length: 3 }, () => Array(3).fill(0))
+                }
+        },
+        {
+                name: 'Bottleneck Wizard',
+                description: 'Slow middle wizard illustrates queueing delays.',
+                data: {
+                        skill: [2, 8, 3],
+                        mana: [4, 3, 6, 2],
+                        grid: Array.from({ length: 3 }, () => Array(4).fill(0))
+                }
+        }
+];
+
+export const minTimeToBrewPotionsPlugin: AlgorithmPlugin<BrewingInput, BrewingState> = {
+        id: 'min-time-to-brew-potions',
+        name: 'Minimum Time to Brew Potions',
+        description:
+                'Simulates potion batches flowing through wizards with different skills. Highlights synchronized hand-offs, waits, and the overall makespan.',
+        category: 'Dynamic Programming',
+        subcategory: 'Scheduling & Pipelines',
+        visualizationType: 'grid',
+        presets,
+        trace,
+        validateInput
+};

--- a/src/routes/[category]/[algorithm]/+page.svelte
+++ b/src/routes/[category]/[algorithm]/+page.svelte
@@ -22,6 +22,7 @@
         import { uniquePathsWithObstaclesPlugin } from '$lib/plugins/uniquePathsWithObstacles';
         import { swimInWaterPlugin } from '$lib/plugins/swimInWater';
         import { findGCDPlugin } from '$lib/plugins/findGCD';
+        import { minTimeToBrewPotionsPlugin } from '$lib/plugins/minTimeToBrewPotions';
         import type { HighlightRole, Trace } from '$lib/types';
         import { HIGHLIGHT_ROLES } from '$lib/types';
 
@@ -29,12 +30,13 @@
 	let { data }: { data: PageData } = $props();
 
 	// Map plugin IDs to plugin instances
-	const pluginMap = {
-		'trapping-rain-water-2': trappingRainWater2Plugin,
-		'unique-paths-with-obstacles': uniquePathsWithObstaclesPlugin,
-		'swim-in-water': swimInWaterPlugin,
-		'find-gcd-array': findGCDPlugin
-	} as const;
+        const pluginMap = {
+                'trapping-rain-water-2': trappingRainWater2Plugin,
+                'unique-paths-with-obstacles': uniquePathsWithObstaclesPlugin,
+                'swim-in-water': swimInWaterPlugin,
+                'find-gcd-array': findGCDPlugin,
+                'min-time-to-brew-potions': minTimeToBrewPotionsPlugin
+        } as const;
 
 	// Get algorithm plugin based on pluginId from route
 	const algorithm = $derived(pluginMap[data.pluginId as keyof typeof pluginMap]);
@@ -47,9 +49,15 @@
 	let currentPreset = $derived(algorithm.presets[selectedPresetIndex]);
 
 	// Grid mode based on algorithm
-	let gridMode = $derived(
-		algorithm.id === 'unique-paths-with-obstacles' ? ('obstacle' as const) : ('height' as const)
-	); // swim-in-water and trapping-rain-water-2 use 'height' mode
+        let gridMode = $derived(() => {
+                if (algorithm.id === 'unique-paths-with-obstacles') {
+                        return 'obstacle' as const;
+                }
+                if (algorithm.id === 'min-time-to-brew-potions') {
+                        return 'dp' as const;
+                }
+                return 'height' as const;
+        }); // swim-in-water and trapping-rain-water-2 use 'height' mode
 
 	// Extract grid data based on algorithm
 	let gridData = $derived.by(() => {

--- a/src/routes/[category]/[algorithm]/+page.svelte
+++ b/src/routes/[category]/[algorithm]/+page.svelte
@@ -60,11 +60,26 @@
         }); // swim-in-water and trapping-rain-water-2 use 'height' mode
 
 	// Extract grid data based on algorithm
-	let gridData = $derived.by(() => {
-		const data = currentPreset.data;
-		// swimInWater has { grid: number[][] }, others have raw number[][]
-		return data.grid ? data.grid : data;
-	});
+        let gridData = $derived.by(() => {
+                const frameGrid = controller.currentFrame?.state?.grid;
+                if (Array.isArray(frameGrid) && frameGrid.length > 0) {
+                        return frameGrid;
+                }
+
+                const data = currentPreset.data as unknown;
+                if (data && typeof data === 'object' && 'grid' in (data as Record<string, unknown>)) {
+                        const presetGrid = (data as { grid?: unknown }).grid;
+                        if (Array.isArray(presetGrid)) {
+                                return presetGrid as number[][];
+                        }
+                }
+
+                if (Array.isArray(data) && data.every((row) => Array.isArray(row))) {
+                        return data as number[][];
+                }
+
+                return [] as number[][];
+        });
 
 	// Format priority queue data for display
         let queueData = $derived.by(() => {

--- a/tests/unit/navigation/navigation-tree-data.test.ts
+++ b/tests/unit/navigation/navigation-tree-data.test.ts
@@ -183,9 +183,9 @@ describe('Navigation Tree Data Structure', () => {
 		});
 	});
 
-	describe('initial algorithm content', () => {
-		it('should contain exactly 3 initial algorithms', () => {
-			const algorithms: AlgorithmNode[] = [];
+        describe('initial algorithm content', () => {
+                it('should contain exactly 5 initial algorithms', () => {
+                        const algorithms: AlgorithmNode[] = [];
 
 			function collectAlgorithms(nodes: typeof navigationTree.rootNodes): void {
 				for (const node of nodes) {
@@ -199,8 +199,8 @@ describe('Navigation Tree Data Structure', () => {
 
 			collectAlgorithms(navigationTree.rootNodes);
 
-			expect(algorithms).toHaveLength(4);
-		});
+                        expect(algorithms).toHaveLength(5);
+                });
 
 		it('should contain trapping-rain-water-2 algorithm', () => {
 			const algorithms: AlgorithmNode[] = [];


### PR DESCRIPTION
## Summary
- document the Minimum Time to Brew Potions visualization goals, constraints, and acceptance scenarios
- implement a synchronized brewing pipeline plugin with timeline alignment, wait metrics, and presets
- register the plugin in navigation/UI and add automated coverage for validation, trace output, and navigation counts

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e80f76a214832685d31b45bb9013cd